### PR TITLE
Fix Command loop after set position command

### DIFF
--- a/components/elero/cover/EleroCover.cpp
+++ b/components/elero/cover/EleroCover.cpp
@@ -43,6 +43,7 @@ void EleroCover::loop() {
     if(this->is_at_target()) {
       this->commands_to_send_.push(this->command_stop_);
       this->current_operation = COVER_OPERATION_IDLE;
+      this->target_position_ = COVER_OPEN;
     }
 
     // Publish position every second


### PR DESCRIPTION
Fixes an issue where using the Set Position % command would override subsequent input from the original remote.
[Link to Issue](https://github.com/andyboeh/esphome-elero/issues/12)